### PR TITLE
Update /refresh to set Content-type header to JSON

### DIFF
--- a/internal/api/v1/handlers/handlers.go
+++ b/internal/api/v1/handlers/handlers.go
@@ -101,7 +101,7 @@ func RegisterRoutes(mux *http.ServeMux, handlerOptions ...HandlerOption) error {
 
 	mux.Handle("GET /v1/identity-providers", logger(ListGlobalResource("identityproviders", h.ListGlobalIdentityProviders)))
 
-	mux.Handle("POST /v1/refresh", logger(requireRefresh(GetNamelessResource(h.GetGlobalTokens))))
+	mux.Handle("POST /v1/refresh", logger(requireRefresh(contentJSON(GetNamelessResource(h.GetGlobalTokens)))))
 
 	mux.Handle("GET /v1/cluster-options", logger(requireAuth(GetNamelessResource(h.GetClusterOptions))))
 


### PR DESCRIPTION
Currently `/refresh` returns a body formatted as JSON but sets the
`Content-Type` header to `text/plain`. This does not allow with the
OpenAPI spec in sudoswedenab/dockyards-api, which means that the
generated client cannot be used correctly in sudoswedenab/dockyardsctl.

This commit ensures that `Content-Type` is set to `application/json` as
per OpenAPI spec
