### PR TITLE
Update /orgs to return displayName

### DIFF
--- a/internal/api/v1/handlers/orgs.go
+++ b/internal/api/v1/handlers/orgs.go
@@ -66,6 +66,10 @@ func (h *handler) ListGlobalOrganizations(ctx context.Context) (*[]types.Organiz
 			Name:      organization.Name,
 		}
 
+		if organization.Spec.DisplayName != "" {
+			v1Organization.DisplayName = &organization.Spec.DisplayName
+		}
+
 		if !organization.DeletionTimestamp.IsZero() {
 			v1Organization.DeletedAt = &organization.CreationTimestamp.Time
 		}

--- a/internal/api/v1/handlers/orgs_test.go
+++ b/internal/api/v1/handlers/orgs_test.go
@@ -95,10 +95,9 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:          string(organization.UID),
-				Name:        organization.Name,
-				DisplayName: &organization.Spec.DisplayName,
-				CreatedAt:   organization.CreationTimestamp.Time,
+				ID:        string(organization.UID),
+				Name:      organization.Name,
+				CreatedAt: organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -137,10 +136,9 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:          string(organization.UID),
-				Name:        organization.Name,
-				DisplayName: &organization.Spec.DisplayName,
-				CreatedAt:   organization.CreationTimestamp.Time,
+				ID:        string(organization.UID),
+				Name:      organization.Name,
+				CreatedAt: organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -179,10 +177,9 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:          string(organization.UID),
-				Name:        organization.Name,
-				DisplayName: &organization.Spec.DisplayName,
-				CreatedAt:   organization.CreationTimestamp.Time,
+				ID:        string(organization.UID),
+				Name:      organization.Name,
+				CreatedAt: organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -197,6 +194,7 @@ func TestGlobalOrganizations_List(t *testing.T) {
 				GenerateName: "other-",
 			},
 			Spec: dockyardsv1.OrganizationSpec{
+				DisplayName: "testing",
 				MemberRefs: []dockyardsv1.OrganizationMemberReference{
 					{
 						TypedLocalObjectReference: corev1.TypedLocalObjectReference{
@@ -250,15 +248,14 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:          string(organization.UID),
-				Name:        organization.Name,
-				DisplayName: &organization.Spec.DisplayName,
-				CreatedAt:   organization.CreationTimestamp.Time,
+				ID:        string(organization.UID),
+				Name:      organization.Name,
+				CreatedAt: organization.CreationTimestamp.Time,
 			},
 			{
 				ID:          string(otherOrganization.UID),
 				Name:        otherOrganization.Name,
-				DisplayName: &organization.Spec.DisplayName,
+				DisplayName: &otherOrganization.Spec.DisplayName,
 				CreatedAt:   otherOrganization.CreationTimestamp.Time,
 			},
 		}
@@ -993,12 +990,11 @@ func TestGlobalOrganizations_Get(t *testing.T) {
 		}
 
 		expected := apitypes.Organization{
-			ID:          string(otherOrganization.UID),
-			Name:        otherOrganization.Name,
-			DisplayName: &organization.Spec.DisplayName,
-			ProviderID:  otherOrganization.Spec.ProviderID,
-			CreatedAt:   otherOrganization.CreationTimestamp.Time,
-			DeletedAt:   &otherOrganization.DeletionTimestamp.Time,
+			ID:         string(otherOrganization.UID),
+			Name:       otherOrganization.Name,
+			ProviderID: otherOrganization.Spec.ProviderID,
+			CreatedAt:  otherOrganization.CreationTimestamp.Time,
+			DeletedAt:  &otherOrganization.DeletionTimestamp.Time,
 		}
 
 		if !cmp.Equal(actual, expected) {
@@ -1060,7 +1056,6 @@ func TestGlobalOrganizations_Get(t *testing.T) {
 		expected := apitypes.Organization{
 			ID:                      string(otherOrganization.UID),
 			Name:                    otherOrganization.Name,
-			DisplayName:             &organization.Spec.DisplayName,
 			ProviderID:              otherOrganization.Spec.ProviderID,
 			CreatedAt:               otherOrganization.CreationTimestamp.Time,
 			CredentialReferenceName: ptr.To("testing"),

--- a/internal/api/v1/handlers/orgs_test.go
+++ b/internal/api/v1/handlers/orgs_test.go
@@ -95,9 +95,10 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:        string(organization.UID),
-				Name:      organization.Name,
-				CreatedAt: organization.CreationTimestamp.Time,
+				ID:          string(organization.UID),
+				Name:        organization.Name,
+				DisplayName: &organization.Spec.DisplayName,
+				CreatedAt:   organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -136,9 +137,10 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:        string(organization.UID),
-				Name:      organization.Name,
-				CreatedAt: organization.CreationTimestamp.Time,
+				ID:          string(organization.UID),
+				Name:        organization.Name,
+				DisplayName: &organization.Spec.DisplayName,
+				CreatedAt:   organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -177,9 +179,10 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:        string(organization.UID),
-				Name:      organization.Name,
-				CreatedAt: organization.CreationTimestamp.Time,
+				ID:          string(organization.UID),
+				Name:        organization.Name,
+				DisplayName: &organization.Spec.DisplayName,
+				CreatedAt:   organization.CreationTimestamp.Time,
 			},
 		}
 
@@ -247,14 +250,16 @@ func TestGlobalOrganizations_List(t *testing.T) {
 
 		expected := []apitypes.Organization{
 			{
-				ID:        string(organization.UID),
-				Name:      organization.Name,
-				CreatedAt: organization.CreationTimestamp.Time,
+				ID:          string(organization.UID),
+				Name:        organization.Name,
+				DisplayName: &organization.Spec.DisplayName,
+				CreatedAt:   organization.CreationTimestamp.Time,
 			},
 			{
-				ID:        string(otherOrganization.UID),
-				Name:      otherOrganization.Name,
-				CreatedAt: otherOrganization.CreationTimestamp.Time,
+				ID:          string(otherOrganization.UID),
+				Name:        otherOrganization.Name,
+				DisplayName: &organization.Spec.DisplayName,
+				CreatedAt:   otherOrganization.CreationTimestamp.Time,
 			},
 		}
 
@@ -925,7 +930,6 @@ func TestGlobalOrganizations_Get(t *testing.T) {
 		if statusCode != http.StatusUnauthorized {
 			t.Fatalf("expected status code %d, got %d", http.StatusUnauthorized, statusCode)
 		}
-
 	})
 
 	t.Run("test deleted organization", func(t *testing.T) {
@@ -989,11 +993,12 @@ func TestGlobalOrganizations_Get(t *testing.T) {
 		}
 
 		expected := apitypes.Organization{
-			ID:         string(otherOrganization.UID),
-			Name:       otherOrganization.Name,
-			ProviderID: otherOrganization.Spec.ProviderID,
-			CreatedAt:  otherOrganization.CreationTimestamp.Time,
-			DeletedAt:  &otherOrganization.DeletionTimestamp.Time,
+			ID:          string(otherOrganization.UID),
+			Name:        otherOrganization.Name,
+			DisplayName: &organization.Spec.DisplayName,
+			ProviderID:  otherOrganization.Spec.ProviderID,
+			CreatedAt:   otherOrganization.CreationTimestamp.Time,
+			DeletedAt:   &otherOrganization.DeletionTimestamp.Time,
 		}
 
 		if !cmp.Equal(actual, expected) {
@@ -1055,6 +1060,7 @@ func TestGlobalOrganizations_Get(t *testing.T) {
 		expected := apitypes.Organization{
 			ID:                      string(otherOrganization.UID),
 			Name:                    otherOrganization.Name,
+			DisplayName:             &organization.Spec.DisplayName,
 			ProviderID:              otherOrganization.Spec.ProviderID,
 			CreatedAt:               otherOrganization.CreationTimestamp.Time,
 			CredentialReferenceName: ptr.To("testing"),

--- a/pkg/testing/testingutil/testingutil.go
+++ b/pkg/testing/testingutil/testingutil.go
@@ -15,11 +15,11 @@
 package testingutil
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
 
-	"context"
 	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
 	"github.com/sudoswedenab/dockyards-backend/pkg/authorization"
 	authorizationv1 "k8s.io/api/authorization/v1"
@@ -122,6 +122,7 @@ func (e *TestEnvironment) CreateOrganization(ctx context.Context) (*dockyardsv1.
 			GenerateName: "test-",
 		},
 		Spec: dockyardsv1.OrganizationSpec{
+			DisplayName: "test",
 			MemberRefs: []dockyardsv1.OrganizationMemberReference{
 				{
 					TypedLocalObjectReference: corev1.TypedLocalObjectReference{
@@ -282,7 +283,6 @@ func RetryUntilFound(ctx context.Context, reader client.Reader, obj client.Objec
 
 		return err
 	})
-
 	if err != nil {
 		return err
 	}

--- a/pkg/testing/testingutil/testingutil.go
+++ b/pkg/testing/testingutil/testingutil.go
@@ -122,7 +122,6 @@ func (e *TestEnvironment) CreateOrganization(ctx context.Context) (*dockyardsv1.
 			GenerateName: "test-",
 		},
 		Spec: dockyardsv1.OrganizationSpec{
-			DisplayName: "test",
 			MemberRefs: []dockyardsv1.OrganizationMemberReference{
 				{
 					TypedLocalObjectReference: corev1.TypedLocalObjectReference{


### PR DESCRIPTION
Currently `/orgs` returns a small subset of all fields associated with
an Organization object.

This commit ensures that the small subset includes `DisplayName` to make
it easier to work with organizations using API/ctl.
