### PR TITLE
Fix deletion timestamps in list global organizations handler

### DIFF
--- a/internal/api/v1/handlers/orgs.go
+++ b/internal/api/v1/handlers/orgs.go
@@ -71,7 +71,7 @@ func (h *handler) ListGlobalOrganizations(ctx context.Context) (*[]types.Organiz
 		}
 
 		if !organization.DeletionTimestamp.IsZero() {
-			v1Organization.DeletedAt = &organization.CreationTimestamp.Time
+			v1Organization.DeletedAt = &organization.DeletionTimestamp.Time
 		}
 
 		if organization.Spec.Duration != nil {


### PR DESCRIPTION
Currently the listed organizations incorrectly uses the creation time stamp for the deleted at field in deleting organizations.