### PR TITLE
Update node pool handlers to support creation time stamps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/client_golang v1.22.0
 	github.com/rs/cors v1.11.0
 	github.com/spf13/pflag v1.0.6
-	github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250806105842-71fe5d4ba31e
+	github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250908121648-77e229d4e68b
 	github.com/sudoswedenab/dockyards-backend/api v1.2.3
 	golang.org/x/crypto v0.38.0
 	k8s.io/api v0.33.1

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
-github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250806105842-71fe5d4ba31e h1:PMsoTHf+oi6CMTdakXwAyVsxoGXV+A5f12AI6BKrqM4=
-github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250806105842-71fe5d4ba31e/go.mod h1:vrza2nx/tVgIUTq0AqA/jzyWNstlyVdcpzh+1+mu22s=
+github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250908121648-77e229d4e68b h1:yWIVKF0gX2yYHzkfn7izbB7xO3zcq4KauAOMEf6orDs=
+github.com/sudoswedenab/dockyards-api/pkg v0.0.0-20250908121648-77e229d4e68b/go.mod h1:vrza2nx/tVgIUTq0AqA/jzyWNstlyVdcpzh+1+mu22s=
 github.com/tetratelabs/wazero v1.6.0 h1:z0H1iikCdP8t+q341xqepY4EWvHEw8Es7tlqiVzlP3g=
 github.com/tetratelabs/wazero v1.6.0/go.mod h1:0U0G41+ochRKoPKCJlh0jMg1CHkyfK8kDqiirMmKY8A=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/internal/api/v1/handlers/node_pools.go
+++ b/internal/api/v1/handlers/node_pools.go
@@ -39,8 +39,9 @@ const maxReplicas = 9
 
 func (h *handler) toV1NodePool(nodePool *dockyardsv1.NodePool, nodeList *dockyardsv1.NodeList) *types.NodePool {
 	v1NodePool := types.NodePool{
-		ID:   string(nodePool.UID),
-		Name: nodePool.Name,
+		CreatedAt: nodePool.CreationTimestamp.Time,
+		ID:        string(nodePool.UID),
+		Name:      nodePool.Name,
 	}
 
 	resourceCPU := nodePool.Spec.Resources.Cpu()
@@ -68,8 +69,9 @@ func (h *handler) toV1NodePool(nodePool *dockyardsv1.NodePool, nodeList *dockyar
 		nodes := make([]types.Node, len(nodeList.Items))
 		for i, node := range nodeList.Items {
 			nodes[i] = types.Node{
-				ID:   string(node.UID),
-				Name: node.Name,
+				CreatedAt: node.CreationTimestamp.Time,
+				ID:        string(node.UID),
+				Name:      node.Name,
 			}
 		}
 
@@ -421,7 +423,7 @@ func (h *handler) ListClusterNodePools(ctx context.Context, cluster *dockyardsv1
 
 	for _, item := range nodePoolList.Items {
 		nodePool := types.NodePool{
-			CreatedAt: &item.CreationTimestamp.Time,
+			CreatedAt: item.CreationTimestamp.Time,
 			ID:        string(item.UID),
 			Name:      item.Name,
 		}

--- a/internal/api/v1/handlers/node_pools_test.go
+++ b/internal/api/v1/handlers/node_pools_test.go
@@ -146,12 +146,14 @@ func TestClusterNodePools_Get(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:   string(nodePool.UID),
-			Name: nodePool.Name,
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
 			Nodes: &[]types.Node{
 				{
-					ID:   string(node.UID),
-					Name: node.Name,
+					CreatedAt: node.CreationTimestamp.Time,
+					ID:        string(node.UID),
+					Name:      node.Name,
 				},
 			},
 		}
@@ -190,12 +192,14 @@ func TestClusterNodePools_Get(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:   string(nodePool.UID),
-			Name: nodePool.Name,
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
 			Nodes: &[]types.Node{
 				{
-					ID:   string(node.UID),
-					Name: node.Name,
+					CreatedAt: node.CreationTimestamp.Time,
+					ID:        string(node.UID),
+					Name:      node.Name,
 				},
 			},
 		}
@@ -234,12 +238,14 @@ func TestClusterNodePools_Get(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:   string(nodePool.UID),
-			Name: nodePool.Name,
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
 			Nodes: &[]types.Node{
 				{
-					ID:   string(node.UID),
-					Name: node.Name,
+					CreatedAt: node.CreationTimestamp.Time,
+					ID:        string(node.UID),
+					Name:      node.Name,
 				},
 			},
 		}
@@ -1627,9 +1633,10 @@ func TestClusterNodePools_Create(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:       string(nodePool.UID),
-			Name:     nodePool.Name,
-			Quantity: ptr.To(0),
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
+			Quantity:  ptr.To(0),
 		}
 
 		if !cmp.Equal(actual, expected) {
@@ -1692,9 +1699,10 @@ func TestClusterNodePools_Create(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:       string(nodePool.UID),
-			Name:     nodePool.Name,
-			Quantity: ptr.To(0),
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
+			Quantity:  ptr.To(0),
 		}
 
 		if !cmp.Equal(actual, expected) {
@@ -1790,6 +1798,7 @@ func TestClusterNodePools_Create(t *testing.T) {
 		}
 
 		expected := types.NodePool{
+			CreatedAt:                  nodePool.CreationTimestamp.Time,
 			ControlPlaneComponentsOnly: ptr.To(true),
 			CPUCount:                   ptr.To(12),
 			DiskSize:                   ptr.To("123Gi"),
@@ -1866,9 +1875,10 @@ func TestClusterNodePools_Create(t *testing.T) {
 		}
 
 		expected := types.NodePool{
-			ID:       string(nodePool.UID),
-			Name:     nodePool.Name,
-			Quantity: ptr.To(3),
+			CreatedAt: nodePool.CreationTimestamp.Time,
+			ID:        string(nodePool.UID),
+			Name:      nodePool.Name,
+			Quantity:  ptr.To(3),
 			StorageResources: &[]types.StorageResource{
 				{
 					Name:     "test",


### PR DESCRIPTION
Currently the creation timestamps on node pools are omitted entirely.