### PR TITLE
Mark merge strategy of go.mod and go.sum like binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+go.mod merge=binary
+go.sum merge=binary


### PR DESCRIPTION
This means that we should be getting fewer merge conflicts while rebasing
when you have both regenerated the go mod.