### PR TITLE
Add Role to CreateOrganizationInvitation() response

### DIFF
--- a/internal/api/v1/handlers/invitations.go
+++ b/internal/api/v1/handlers/invitations.go
@@ -70,6 +70,7 @@ func (h *handler) CreateOrganizationInvitation(ctx context.Context, organization
 		ID:        string(invitation.UID),
 		Name:      invitation.Name,
 		CreatedAt: invitation.CreationTimestamp.Time,
+		Role: 	   string(invitation.Spec.Role),
 	}
 
 	return &response, nil


### PR DESCRIPTION
The API spec says that this field is required, so by not including it, it defaults to empty string, which it not correct.