### PR TITLE
Add api/config sub-module for config management

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -1,0 +1,105 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// DockyardsConfig holds the configuration data for a Dockyards installation,
+// including its name, namespace, and a map of configuration settings.
+type DockyardsConfig struct {
+	name      string
+	namespace string
+	config    map[string]string
+	mutex     sync.Mutex
+}
+
+// GetConfig retrieves the configuration from the specified ConfigMap in the given namespace
+// and returns it as a DockyardsConfig instance.
+func GetConfig(ctx context.Context, c client.Client, configMap, dockyardsNamespace string) (*DockyardsConfig, error) {
+	config := DockyardsConfig{
+		name:      configMap,
+		namespace: dockyardsNamespace,
+	}
+
+	cm := corev1.ConfigMap{}
+	err := c.Get(ctx, client.ObjectKey{Name: configMap, Namespace: dockyardsNamespace}, &cm)
+	if err != nil {
+		return &DockyardsConfig{}, err
+	}
+
+	config.config = cm.Data
+
+	return &config, nil
+}
+
+// GetConfigKey retrieves the value for the specified key from the configuration,
+// returning the provided defaultValue if the key is not present or the config is nil.
+func (config *DockyardsConfig) GetConfigKey(key, defaultValue string) string {
+	c := (*config).config
+	if c == nil || c[key] == "" {
+		return defaultValue
+	}
+
+	return c[key]
+}
+
+// SetConfigKey sets the value for the specified key in the configuration and updates the ConfigMap
+// in the Kubernetes cluster.
+func (config *DockyardsConfig) SetConfigKey(ctx context.Context, c client.Client, key, value string) error {
+	config.mutex.Lock()
+	defer config.mutex.Unlock()
+
+	if config.config == nil {
+		config.config = make(map[string]string)
+	}
+
+	config.config[key] = value
+	err := config.setConfig(ctx, c)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// setConfig updates the ConfigMap in the Kubernetes cluster with the current configuration data.
+func (config *DockyardsConfig) setConfig(ctx context.Context, c client.Client) error {
+	cm := corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      config.name,
+			Namespace: config.namespace,
+		},
+	}
+	err := c.Get(ctx, client.ObjectKeyFromObject(&cm), &cm)
+	if err != nil {
+		return err
+	}
+
+	cm.Data = config.config
+
+	err = c.Update(ctx, &cm)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/api/config/config_test.go
+++ b/api/config/config_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sudoswedenab/dockyards-backend/api/config"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestConfig(t *testing.T) {
+	ctx := context.Background()
+
+	scheme := scheme.Scheme
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	cmName := "dockyards-config"
+	cmNamespace := "dockyards-system"
+	url := "http://test.com"
+
+	configMap := corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      cmName,
+			Namespace: cmNamespace,
+		},
+		Data: map[string]string{
+			"externalUrl": url,
+		},
+	}
+
+	err := fakeClient.Create(ctx, &configMap)
+	if err != nil {
+		t.Fatalf("error creating config map: %s", err)
+	}
+
+	t.Run("get dockyards config", func(t *testing.T) {
+		_, err := config.GetConfig(ctx, fakeClient, cmName, cmNamespace)
+		if err != nil {
+			t.Fatalf("error getting config: %s", err)
+		}
+	})
+
+	t.Run("get key from dockyards config", func(t *testing.T) {
+		c, err := config.GetConfig(ctx, fakeClient, cmName, cmNamespace)
+		if err != nil {
+			t.Fatalf("error getting config: %s", err)
+		}
+
+		eUrl := c.GetConfigKey("externalUrl", "http://default.com")
+		if eUrl != url {
+			t.Fatalf("The externalUrl does not match the expected value: expected \"%s\", got \"%s\"", url, eUrl)
+		}
+	})
+
+	t.Run("get default for key from dockyards config", func(t *testing.T) {
+		c, err := config.GetConfig(ctx, fakeClient, cmName, cmNamespace)
+		if err != nil {
+			t.Fatalf("error getting config: %s", err)
+		}
+
+		defaultValue := "defaultForNonExistent"
+
+		nonExistent := c.GetConfigKey("nonExistent", defaultValue)
+		if nonExistent != defaultValue {
+			t.Fatalf("The non-existent key does not match the default value: expected \"%s\", got \"%s\"", defaultValue, nonExistent)
+		}
+	})
+
+	t.Run("set a key in dockyards config", func(t *testing.T) {
+		c, err := config.GetConfig(ctx, fakeClient, cmName, cmNamespace)
+		if err != nil {
+			t.Fatalf("error getting config: %s", err)
+		}
+
+		oldValue := c.GetConfigKey("externalUrl", "http://default.com")
+
+		err = c.SetConfigKey(ctx, fakeClient, "externalUrl", "http://new.com")
+		if err != nil {
+			t.Fatalf("error setting key in config: %s", err)
+		}
+
+		newValue := c.GetConfigKey("externalUrl", "http://default.com")
+		if oldValue == newValue {
+			t.Fatalf("The key was not updated in kubernetes ConfigMap")
+		}
+	})
+}


### PR DESCRIPTION
As the configuration for Dockyards services grows more complex, we are
considering moving away from flags to using a "config file-like"
approach using a Kubernetes ConfigMap resource or similar.

This commit introduces a sub-module `dockyards-backend/api/config` that
(for now) is used to configure ExternalURL for Dockyards. This is done
in a submodule with the idea that other components can use the same
approach for configuration.
