### PR TITLE
Update User reconciler to accept dockyards config as input

### DIFF
--- a/internal/controller/user_controller.go
+++ b/internal/controller/user_controller.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/fluxcd/pkg/runtime/conditions"
 	"github.com/fluxcd/pkg/runtime/patch"
+	dyconfig "github.com/sudoswedenab/dockyards-backend/api/config"
 	"github.com/sudoswedenab/dockyards-backend/templates"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,7 @@ import (
 
 type UserReconciler struct {
 	client.Client
-	DockyardsExternalURL string
+	DockyardsConfig *dyconfig.DockyardsConfig
 }
 
 type VerificationEmail struct {
@@ -186,7 +187,8 @@ func (r *UserReconciler) reconcileVerificationRequest(ctx context.Context, user 
 			name = user.Spec.DisplayName
 		}
 
-		verificationEmail, err := renderVerificationEmail(VerificationEmailSpec{VerificationURL: r.DockyardsExternalURL + "/verify/" + code, Name: name})
+		externalURL := r.DockyardsConfig.GetConfigKey(dyconfig.KeyExternalURL, "http://localhost:9000")
+		verificationEmail, err := renderVerificationEmail(VerificationEmailSpec{VerificationURL: externalURL + "/verify/" + code, Name: name})
 		if err != nil {
 			return err
 		}

--- a/main.go
+++ b/main.go
@@ -335,18 +335,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	cm, err := dyconfig.GetConfig(ctx, controllerClient, configMap, dockyardsNamespace)
+	dockyardsConfig, err := dyconfig.GetConfig(ctx, controllerClient, configMap, dockyardsNamespace)
 	if err != nil {
 		logger.Error("error loading config map", "err", err)
 
 		os.Exit(1)
 	}
 
-	externalURL := cm.GetConfigKey(dyconfig.KeyExternalURL, "http://localhost:9000")
-
 	err = (&controller.UserReconciler{
-		Client:               mgr.GetClient(),
-		DockyardsExternalURL: externalURL,
+		Client:          mgr.GetClient(),
+		DockyardsConfig: dockyardsConfig,
 	}).SetupWithManager(mgr)
 	if err != nil {
 		logger.Error("error creating new verificationrequest reconciler", "err", err)


### PR DESCRIPTION
Currently the app fetches Dockyards Config on startup, extracts
`externalURL` key and passes it on to the User reconciler. While this
works fine, we will most likely want to reload Dockyards Config
dynamically in future, hence we will need to propagate the updates to
whatever reconcilers use the Dockyards Config. To make that simpler, we
can pass the reference to the DY Config to the reconcilers and let them
extract the keys themselves.

This commit updates User reconciler to expect a reference to the
DockyardsConfig and extract the key itself
