### PR TITLE
Add experimental v2 api

### DIFF
--- a/internal/api/v2/get.go
+++ b/internal/api/v2/get.go
@@ -1,0 +1,122 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (a *API) GetNamespacedResource(w http.ResponseWriter, r *http.Request) {
+	subject, err := a.subjectFrom(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	ctx := r.Context()
+
+	group := r.PathValue("group")
+	version := r.PathValue("version")
+	kind := r.PathValue("kind")
+
+	key := client.ObjectKey{
+		Name: kind + "." + group,
+	}
+
+	var customResourceDefinition apiextensionsv1.CustomResourceDefinition
+	err = a.Get(ctx, key, &customResourceDefinition)
+	if err != nil {
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	namespace := r.PathValue("namespace")
+	name := r.PathValue("name")
+
+	groupVersionKind := schema.GroupVersionKind{
+		Group:   group,
+		Version: version,
+		Kind:    customResourceDefinition.Spec.Names.Kind,
+	}
+
+	resourceAttributes := authorizationv1.ResourceAttributes{
+		Group:     group,
+		Name:      name,
+		Namespace: namespace,
+		Resource:  customResourceDefinition.Spec.Names.Plural,
+		Verb:      "list",
+		Version:   version,
+	}
+
+	allowed, err := apiutil.IsSubjectAllowed(ctx, a, subject, &resourceAttributes)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if !allowed {
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	var u unstructured.Unstructured
+	u.SetGroupVersionKind(groupVersionKind)
+
+	key = client.ObjectKey{
+		Name:      name,
+		Namespace: namespace,
+	}
+
+	err = a.Get(ctx, key, &u)
+	if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+		w.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	b, err := json.Marshal(u.Object)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+}

--- a/internal/api/v2/list.go
+++ b/internal/api/v2/list.go
@@ -1,0 +1,130 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
+	authorizationv1 "k8s.io/api/authorization/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (a *API) ListNamespacedResource(w http.ResponseWriter, r *http.Request) {
+	subject, err := a.subjectFrom(r)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	ctx := r.Context()
+
+	group := r.PathValue("group")
+	version := r.PathValue("version")
+	kind := r.PathValue("kind")
+	namespace := r.PathValue("namespace")
+
+	key := client.ObjectKey{
+		Name: kind + "." + group,
+	}
+
+	var customResourceDefinition apiextensionsv1.CustomResourceDefinition
+	err = a.Get(ctx, key, &customResourceDefinition)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	groupVersionKind := schema.GroupVersionKind{
+		Group:   group,
+		Version: version,
+		Kind:    customResourceDefinition.Spec.Names.Kind,
+	}
+
+	resourceAttributes := authorizationv1.ResourceAttributes{
+		Group:     group,
+		Namespace: namespace,
+		Resource:  customResourceDefinition.Spec.Names.Plural,
+		Verb:      "list",
+		Version:   version,
+	}
+
+	allowed, err := apiutil.IsSubjectAllowed(ctx, a, subject, &resourceAttributes)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	if !allowed {
+		w.WriteHeader(http.StatusUnauthorized)
+
+		return
+	}
+
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+
+	labelSelector := r.URL.Query().Get("labelSelector")
+	if labelSelector != "" {
+		set, err := labels.ConvertSelectorToLabelsMap(labelSelector)
+		if err != nil {
+			panic(err)
+		}
+
+		matchingLabelsSelector := client.MatchingLabelsSelector{
+			Selector: set.AsSelector(),
+		}
+
+		opts = append(opts, matchingLabelsSelector)
+	}
+
+	var u unstructured.UnstructuredList
+	u.SetGroupVersionKind(groupVersionKind)
+
+	err = a.List(ctx, &u, opts...)
+	if meta.IsNoMatchError(err) {
+		w.WriteHeader(http.StatusNotFound)
+
+		return
+	}
+
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	b, err := json.Marshal(&u)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+
+		return
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+}

--- a/internal/api/v2/list_test.go
+++ b/internal/api/v2/list_test.go
@@ -1,0 +1,290 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestNamespacedResource_List(t *testing.T) {
+	ctx := t.Context()
+
+	organization := environment.MustCreateOrganization(t)
+	superUser := environment.MustGetOrganizationUser(t, organization, dockyardsv1.OrganizationMemberRoleSuperUser)
+
+	c := environment.GetClient()
+
+	clusters := []dockyardsv1.Cluster{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    organization.Spec.NamespaceRef.Name,
+			},
+		},
+	}
+
+	for i := range clusters {
+		err := c.Create(ctx, &clusters[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	nodes := []dockyardsv1.Node{
+		{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Labels: map[string]string{
+					dockyardsv1.LabelClusterName: "a",
+				},
+				Namespace: organization.Spec.NamespaceRef.Name,
+			},
+		},
+		{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       dockyardsv1.NodeKind,
+				APIVersion: dockyardsv1.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Labels: map[string]string{
+					dockyardsv1.LabelClusterName: "b",
+				},
+				Namespace: organization.Spec.NamespaceRef.Name,
+			},
+		},
+	}
+
+	for i := range nodes {
+		err := c.Create(ctx, &nodes[i])
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ignoreTypeMeta := cmpopts.IgnoreTypes(metav1.TypeMeta{})
+	ignoreListMeta := cmpopts.IgnoreFields(metav1.ListMeta{}, "ResourceVersion")
+
+	sortNodeByID := cmpopts.SortSlices(func(a, b dockyardsv1.Node) bool {
+		return a.UID < b.UID
+	})
+
+	t.Run("test clusters as super user", func(t *testing.T) {
+		target, err := url.JoinPath("/v2",
+			"group", dockyardsv1.GroupVersion.Group,
+			"version", dockyardsv1.GroupVersion.Version,
+			"kind", "clusters",
+			"namespace", organization.Spec.NamespaceRef.Name,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+
+		r.Header.Add("Authorization", "Bearer "+MustSignToken(superUser))
+
+		mux.ServeHTTP(w, r)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status code %d", w.Result().StatusCode)
+		}
+
+		b, err := io.ReadAll(w.Result().Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual dockyardsv1.ClusterList
+		err = json.Unmarshal(b, &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := dockyardsv1.ClusterList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ClusterList",
+				APIVersion: dockyardsv1.GroupVersion.String(),
+			},
+			Items: clusters,
+		}
+
+		if !cmp.Equal(actual, expected, ignoreListMeta, ignoreTypeMeta) {
+			t.Errorf("diff: %s", cmp.Diff(expected, actual, ignoreListMeta, ignoreTypeMeta))
+		}
+	})
+
+	t.Run("test clusters as other user", func(t *testing.T) {
+		otherOrganization := environment.MustCreateOrganization(t)
+		otherUser := environment.MustGetOrganizationUser(t, otherOrganization, dockyardsv1.OrganizationMemberRoleSuperUser)
+
+		target, err := url.JoinPath("/v2",
+			"group", dockyardsv1.GroupVersion.Group,
+			"version", dockyardsv1.GroupVersion.Version,
+			"kind", "clusters",
+			"namespace", organization.Spec.NamespaceRef.Name,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+
+		r.Header.Add("Authorization", "Bearer "+MustSignToken(otherUser))
+
+		mux.ServeHTTP(w, r)
+
+		if w.Result().StatusCode != http.StatusUnauthorized {
+			t.Fatalf("unexpected status code %d", w.Result().StatusCode)
+		}
+	})
+
+	t.Run("test nodes as user", func(t *testing.T) {
+		target, err := url.JoinPath("/v2",
+			"group", dockyardsv1.GroupVersion.Group,
+			"version", dockyardsv1.GroupVersion.Version,
+			"kind", "nodes",
+			"namespace", organization.Spec.NamespaceRef.Name,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+
+		r.Header.Add("Authorization", "Bearer "+MustSignToken(superUser))
+
+		mux.ServeHTTP(w, r)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status code %d", w.Result().StatusCode)
+		}
+
+		b, err := io.ReadAll(w.Result().Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var actual dockyardsv1.NodeList
+		err = json.Unmarshal(b, &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := dockyardsv1.NodeList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodeList",
+				APIVersion: dockyardsv1.GroupVersion.String(),
+			},
+			Items: nodes,
+		}
+
+		if !cmp.Equal(actual, expected, ignoreListMeta, sortNodeByID, ignoreTypeMeta) {
+			t.Errorf("diff: %s", cmp.Diff(expected, actual, ignoreListMeta, sortNodeByID, ignoreTypeMeta))
+		}
+	})
+
+	t.Run("test nodes label selector", func(t *testing.T) {
+		target, err := url.JoinPath("/v2",
+			"group", dockyardsv1.GroupVersion.Group,
+			"version", dockyardsv1.GroupVersion.Version,
+			"kind", "nodes",
+			"namespace", organization.Spec.NamespaceRef.Name,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		v := url.Values{}
+		v.Add("labelSelector", "dockyards.io/cluster-name=a")
+
+		u := url.URL{
+			Path:     target,
+			RawQuery: v.Encode(),
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, u.String(), nil)
+
+		r.Header.Add("Authorization", "Bearer "+MustSignToken(superUser))
+
+		mux.ServeHTTP(w, r)
+
+		if w.Result().StatusCode != http.StatusOK {
+			t.Fatalf("unexpected status code %d", w.Result().StatusCode)
+		}
+
+		b, err := io.ReadAll(w.Result().Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		var actual dockyardsv1.NodeList
+		err = json.Unmarshal(b, &actual)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		expected := dockyardsv1.NodeList{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "NodeList",
+				APIVersion: dockyardsv1.GroupVersion.String(),
+			},
+			Items: []dockyardsv1.Node{
+				nodes[0],
+			},
+		}
+
+		if !cmp.Equal(actual, expected, ignoreListMeta, sortNodeByID, ignoreTypeMeta) {
+			t.Errorf("diff: %s", cmp.Diff(expected, actual, ignoreListMeta, sortNodeByID, ignoreTypeMeta))
+		}
+	})
+
+	t.Run("test invalid version", func(t *testing.T) {
+		target, err := url.JoinPath("/v2",
+			"group", dockyardsv1.GroupVersion.Group,
+			"version", "v1alpha1",
+			"kind", "nodes",
+			"namespace", organization.Spec.NamespaceRef.Name,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, target, nil)
+
+		r.Header.Add("Authorization", "Bearer "+MustSignToken(superUser))
+
+		mux.ServeHTTP(w, r)
+
+		if w.Result().StatusCode != http.StatusNotFound {
+			t.Fatalf("unexpected status code %d", w.Result().StatusCode)
+		}
+	})
+}

--- a/internal/api/v2/suite_test.go
+++ b/internal/api/v2/suite_test.go
@@ -1,0 +1,93 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"net/http"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	v2 "github.com/sudoswedenab/dockyards-backend/internal/api/v2"
+	"github.com/sudoswedenab/dockyards-backend/pkg/testing/testingutil"
+	utiljwt "github.com/sudoswedenab/dockyards-backend/pkg/util/jwt"
+)
+
+var (
+	environment *testingutil.TestEnvironment
+	mux *http.ServeMux
+	accessKey *ecdsa.PrivateKey
+)
+
+func TestMain(m *testing.M) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var err error
+
+	environment, err = testingutil.NewTestEnvironment(ctx, []string{path.Join("../../../config/crd")})
+	if err != nil {
+		panic(err)
+	}
+
+	mgr := environment.GetManager()
+	c := environment.GetClient()
+
+	go func() {
+		err := mgr.Start(ctx)
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	accessKey, _, err = utiljwt.GetOrGenerateKeys(ctx, c, environment.GetDockyardsNamespace())
+	if err != nil {
+		panic(err)
+	}
+
+	mux = http.NewServeMux()
+
+	a := v2.NewAPI(mgr, &accessKey.PublicKey)
+	a.RegisterRoutes(mux)
+
+	code := m.Run()
+
+	cancel()
+	err = environment.GetEnvironment().Stop()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Exit(code)
+}
+
+func MustSignToken(user *dockyardsv1.User) string {
+	claims := jwt.RegisteredClaims{
+		ExpiresAt: jwt.NewNumericDate(time.Now().Add(time.Minute)),
+		Subject: user.Name,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
+	signed, err := token.SignedString(accessKey)
+	if err != nil {
+		panic(err)
+	}
+
+	return signed
+}

--- a/internal/api/v2/v2.go
+++ b/internal/api/v2/v2.go
@@ -1,0 +1,74 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v2
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"net/http"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+type API struct {
+	client.Client
+	*http.ServeMux
+
+	accessKey crypto.PublicKey
+}
+
+func NewAPI(mgr manager.Manager, accessKey crypto.PublicKey) *API {
+	mux := http.NewServeMux()
+
+	api := API{
+		Client:    mgr.GetClient(),
+		ServeMux:  mux,
+		accessKey: accessKey,
+	}
+
+	return &api
+}
+
+func (a *API) RegisterRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("/v2/group/{group}/version/{version}/kind/{kind}/namespace/{namespace}", a.ListNamespacedResource)
+	mux.HandleFunc("/v2/group/{group}/version/{version}/kind/{kind}/namespace/{namespace}/name/{name}", a.GetNamespacedResource)
+}
+
+func (a *API) subjectFrom(r *http.Request) (string, error) {
+	header := r.Header.Get("Authorization")
+	tokenString := strings.TrimPrefix(header, "Bearer ")
+
+	token, err := jwt.ParseWithClaims(tokenString, &jwt.RegisteredClaims{}, func(t *jwt.Token) (any, error) {
+		_, ok := t.Method.(*jwt.SigningMethodECDSA)
+		if !ok {
+			return nil, jwt.ErrTokenSignatureInvalid
+		}
+
+		return a.accessKey.(*ecdsa.PublicKey), nil
+	})
+	if err != nil {
+		return "", err
+	}
+
+	subject, err := token.Claims.GetSubject()
+	if err != nil {
+		return "", err
+	}
+
+	return subject, nil
+}

--- a/pkg/testing/testingutil/testingutil.go
+++ b/pkg/testing/testingutil/testingutil.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 type TestEnvironment struct {
@@ -227,6 +228,7 @@ func NewTestEnvironment(ctx context.Context, crdDirectoryPaths []string) (*TestE
 	_ = dockyardsv1.AddToScheme(scheme)
 	_ = authorizationv1.AddToScheme(scheme)
 	_ = rbacv1.AddToScheme(scheme)
+	_ = apiextensionsv1.AddToScheme(scheme)
 
 	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {


### PR DESCRIPTION
Currently the v1 api uses custom types that needs to be converted to and from the actual kubernetes resources. This causes a lot of duplicate work where everything must be implemented twice, first as kubernetes resources and then as v1 equivalents.

This adds an experimental v2 api that uses the kubernetes types directly. This is considered experimental as it in still unclear if this is a good approach or not.

In this initial version the v2 support is limited to listing and getting namespaced resources.