### PR TITLE
Add a default aggregate ClusterRole for authenticated users

### DIFF
--- a/api/apiutil/apiutil.go
+++ b/api/apiutil/apiutil.go
@@ -60,13 +60,13 @@ func GetOwnerOrganization(ctx context.Context, c client.Client, o client.Object)
 		}
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.OrganizationKind,
+			Kind:  dockyardsv1.OrganizationKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -102,13 +102,13 @@ func GetOwnerCluster(ctx context.Context, c client.Client, o client.Object) (*do
 		}
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.ClusterKind,
+			Kind:  dockyardsv1.ClusterKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -143,13 +143,13 @@ func GetOwnerNodePool(ctx context.Context, c client.Client, o client.Object) (*d
 		return &nodePool, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.NodePoolKind,
+			Kind:  dockyardsv1.NodePoolKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -179,13 +179,13 @@ func GetOwnerDeployment(ctx context.Context, c client.Client, o client.Object) (
 		return &deployment, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.DeploymentKind,
+			Kind:  dockyardsv1.DeploymentKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -251,13 +251,13 @@ func GetOwnerHelmDeployment(ctx context.Context, c client.Client, o client.Objec
 		return &deployment, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.HelmDeploymentKind,
+			Kind:  dockyardsv1.HelmDeploymentKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -287,13 +287,13 @@ func GetOwnerKustomizeDeployment(ctx context.Context, c client.Client, o client.
 		return &deployment, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.KustomizeDeploymentKind,
+			Kind:  dockyardsv1.KustomizeDeploymentKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -323,13 +323,13 @@ func GetOwnerContainerImageDeployment(ctx context.Context, c client.Client, o cl
 		return &deployment, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.ContainerImageDeploymentKind,
+			Kind:  dockyardsv1.ContainerImageDeploymentKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", o.GetName()),
 	}}
@@ -339,7 +339,7 @@ func IsSubjectAllowed(ctx context.Context, c client.Client, subject string, reso
 	accessReview := authorizationv1.SubjectAccessReview{
 		Spec: authorizationv1.SubjectAccessReviewSpec{
 			Groups: []string{
-				"system:authenticated",
+				"dockyards:authenticated",
 			},
 			User:               subject,
 			ResourceAttributes: resourceAttributes,
@@ -522,13 +522,13 @@ func GetOwnerWorkload(ctx context.Context, c client.Client, obj client.Object) (
 		return &workload, nil
 	}
 
-	return nil, &errors.StatusError{ErrStatus:metav1.Status{
+	return nil, &errors.StatusError{ErrStatus: metav1.Status{
 		Status: metav1.StatusFailure,
 		Code:   http.StatusNotFound,
 		Reason: metav1.StatusReasonNotFound,
 		Details: &metav1.StatusDetails{
 			Group: dockyardsv1.GroupVersion.Group,
-			Kind: dockyardsv1.OrganizationKind,
+			Kind:  dockyardsv1.OrganizationKind,
 		},
 		Message: fmt.Sprintf("could not find owner for %s", obj.GetName()),
 	}}


### PR DESCRIPTION
We are looking into adding support for viewing shared resources that are
not cluster-scoped and are not owned by DY Backend.

This commit:
- adds a new ClusterRole `dockyards:authenticated` that is an aggregate
role to be used for granting users access to auxiliary resources, e.g.
WorkloadForms
- adds a new (User)Group `dockyards:authenticated`, and ensures that all
users are considered part of it (similar to `system:authorized`)

Note that this commit does not include tests specific to this
functionality due to some limitations with `envtest` ephemeral clusters
and aggregate ClusterRoles. These tests will be added at a later stage
