### PR TITLE
Update permissions for creating ClusterRoles

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -123,7 +123,6 @@ rules:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings
-  - clusterroles
   - rolebindings
   - roles
   verbs:
@@ -131,4 +130,16 @@ rules:
   - get
   - list
   - patch
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  verbs:
+  - create
+  - escalate
+  - get
+  - list
+  - patch
+  - update
   - watch

--- a/pkg/authorization/authorization.go
+++ b/pkg/authorization/authorization.go
@@ -338,6 +338,8 @@ func ReconcileOrganizationAuthorization(ctx context.Context, c client.Client, or
 	return nil
 }
 
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=get;list;watch;create;update;patch;escalate
+
 func ReconcileClusterAuthorization(ctx context.Context, client client.Client) error {
 	clusterRole := rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
Currently the application is able to create ClusterRoles but it is not
able to create an aggregated cluster role that was introduced in one of
the previous commits.

This commit adds an annotation to explicitly allow working with cluster
roles and an `escalate` permission that should hopefully allow the app
to create aggregated roles
