### PR TITLE
Use `Key` as the key type of dyconfig data

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -34,7 +34,7 @@ import (
 type ConfigManager struct {
 	client    client.Client
 	backingConfigMapKey client.ObjectKey
-	data      atomic.Pointer[map[string]string]
+	data      atomic.Pointer[map[Key]string]
 	logger    *slog.Logger
 }
 
@@ -68,7 +68,7 @@ func NewConfigManager(mgr ctrl.Manager, backingConfigMapKey client.ObjectKey, op
 	return result, nil
 }
 
-func NewFakeConfigManager(data map[string]string) *ConfigManager {
+func NewFakeConfigManager(data map[Key]string) *ConfigManager {
 	result := &ConfigManager{}
 	result.data.Store(&data)
 	return result
@@ -84,10 +84,16 @@ func (m *ConfigManager) Reconcile(ctx context.Context, req reconcile.Request) (r
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	m.data.Store(&configMap.Data)
+
+	data := make(map[Key]string, len(configMap.Data))
+	for k, v := range configMap.Data {
+		data[Key(k)] = v
+	}
+
+	m.data.Store(&data)
 
 	if m.logger != nil {
-		m.logger.Debug("reloaded config map", "key", m.backingConfigMapKey, "data", configMap.Data)
+		m.logger.Debug("reloaded config map", "key", m.backingConfigMapKey, "data", data)
 	}
 
 	return reconcile.Result{}, nil
@@ -102,7 +108,7 @@ func (m *ConfigManager) GetValueForKey(key Key) (string, bool) {
 	if config == nil {
 		return "", false 
 	}
-	value, ok := config[string(key)]
+	value, ok := config[key]
 	return value, ok
 }
 

--- a/api/config/config.go
+++ b/api/config/config.go
@@ -75,6 +75,10 @@ func NewFakeConfigManager(data map[Key]string) *ConfigManager {
 }
 
 func (m *ConfigManager) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	if m == nil {
+		return reconcile.Result{}, nil
+	}
+
 	if req.NamespacedName != m.backingConfigMapKey {
 		return reconcile.Result{}, nil
 	}
@@ -100,6 +104,10 @@ func (m *ConfigManager) Reconcile(ctx context.Context, req reconcile.Request) (r
 }
 
 func (m *ConfigManager) GetValueForKey(key Key) (string, bool) {
+	if m == nil {
+		return "", false
+	}
+
 	configPtr := m.data.Load()
 	if configPtr == nil {
 		return "", false 
@@ -113,6 +121,10 @@ func (m *ConfigManager) GetValueForKey(key Key) (string, bool) {
 }
 
 func (m *ConfigManager) GetValueOrDefault(key Key, defaultValue string) string {
+	if m == nil {
+		return defaultValue
+	}
+
 	value, ok := m.GetValueForKey(key)
 	if !ok {
 		return defaultValue

--- a/internal/api/v1/handlers/suite_test.go
+++ b/internal/api/v1/handlers/suite_test.go
@@ -133,8 +133,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	fakeConfig := config.NewFakeConfigManager(map[string]string{
-		string(config.KeyPublicNamespace): testEnvironment.GetPublicNamespace(),
+	fakeConfig := config.NewFakeConfigManager(map[config.Key]string{
+		config.KeyPublicNamespace: testEnvironment.GetPublicNamespace(),
 	})
 
 	handlerOptions := []handlers.HandlerOption{

--- a/internal/controller/user_controller_test.go
+++ b/internal/controller/user_controller_test.go
@@ -58,9 +58,9 @@ func TestUserReconciler_Reconcile(t *testing.T) {
 
 	c := testEnvironment.GetClient()
 
-	config := dyconfig.NewFakeConfigManager(map[string]string{
-		string(dyconfig.KeyExternalURL): "http://test.com",
-		string(dyconfig.KeyPublicNamespace): "dockyards-public",
+	config := dyconfig.NewFakeConfigManager(map[dyconfig.Key]string{
+		dyconfig.KeyExternalURL: "http://test.com",
+		dyconfig.KeyPublicNamespace: "dockyards-public",
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Previously, we used `string` as the key type because when I wrote the code for `ConfigManager` I did not want to create a new map when converting from `map[string]string` => `map[Key]string`, since this would be an unnecessary copy. If the go typesystem was smart enough to allow for a cast between the types, everything would be fine, but it seems as though that is not the case :(

This meant that when creating a fake  config manager, we needed to pass it as a `map[string]string` as well, which may have led users of the `ConfigManager` to believe that the keys should be strings rather than `Key`s.

There is also another quite annoying bug in go where `string` can be used in `ConfigManager.GetValueForKey(key Key)` in external packages. This has lead to usage code which works, but is semantically incorrect and should probably not even compile.

Using `Key` as the storage type should hopefully make it more clear that we do in fact want users of the `ConfigManager` to use `dyconfig.Key` for the config keys.