### PR TITLE
Add more validating webhooks

### DIFF
--- a/internal/webhooks/cluster_webhook.go
+++ b/internal/webhooks/cluster_webhook.go
@@ -16,12 +16,12 @@ package webhooks
 
 import (
 	"context"
+	"fmt"
 	"net/netip"
 
 	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
 	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -131,55 +131,35 @@ func (webhook *DockyardsCluster) ValidateUpdate(_ context.Context, oldCluster *d
 }
 
 func (webhook *DockyardsCluster) validate(dockyardsCluster *dockyardsv1.Cluster) error {
-	hasOrganizationOwner := false
-	for _, ownerReference := range dockyardsCluster.OwnerReferences {
-		if ownerReference.Kind != dockyardsv1.OrganizationKind {
-			continue
-		}
+	var errs field.ErrorList
 
-		groupVersion, err := schema.ParseGroupVersion(ownerReference.APIVersion)
-		if err != nil {
-			return err
-		}
-
-		if groupVersion.Group != dockyardsv1.GroupVersion.Group {
-			continue
-		}
-
-		hasOrganizationOwner = true
-	}
-
-	if !hasOrganizationOwner {
-		required := field.Required(
+	owner, err := apiutil.FindOwnerReference(dockyardsCluster, dockyardsv1.OrganizationKind)
+	if err != nil {
+		errs = append(errs, field.Required(
 			field.NewPath("metadata", "ownerReferences"),
-			"must have organization owner reference",
-		)
-		qualifiedKind := dockyardsv1.GroupVersion.WithKind(dockyardsv1.ClusterKind).GroupKind()
-
-		return apierrors.NewInvalid(
-			qualifiedKind,
-			dockyardsCluster.Name,
-			field.ErrorList{
-				required,
-			},
-		)
+			"organization owner reference not found",
+		))
 	}
 
-	errorList := field.ErrorList{}
+	if value := dockyardsCluster.Labels[dockyardsv1.LabelClusterName]; value != owner.Name {
+		errs = append(errs, field.Invalid(
+			field.NewPath("metadata", "labels", dockyardsv1.LabelClusterName),
+			value,
+			fmt.Sprintf("expected '%s'", owner.Name),
+		))
+	}
 
 	prefixes := []netip.Prefix{}
 
 	for i, subnet := range dockyardsCluster.Spec.PodSubnets {
 		newPrefix, err := netip.ParsePrefix(subnet)
 		if err != nil {
-			invalid := field.Invalid(field.NewPath("spec", "podSubnets").Index(i), subnet, "unable to parse pod subnet as prefix")
-			errorList = append(errorList, invalid)
+			errs = append(errs, field.Invalid(field.NewPath("spec", "podSubnets").Index(i), subnet, "unable to parse pod subnet as prefix"))
 		}
 
 		for _, prefix := range prefixes {
 			if newPrefix.Overlaps(prefix) {
-				invalid := field.Invalid(field.NewPath("spec", "podSubnets").Index(i), subnet, "subnet overlaps with prefix "+prefix.String())
-				errorList = append(errorList, invalid)
+				errs = append(errs, field.Invalid(field.NewPath("spec", "podSubnets").Index(i), subnet, "subnet overlaps with prefix "+prefix.String()))
 			}
 		}
 
@@ -189,21 +169,19 @@ func (webhook *DockyardsCluster) validate(dockyardsCluster *dockyardsv1.Cluster)
 	for i, subnet := range dockyardsCluster.Spec.ServiceSubnets {
 		newPrefix, err := netip.ParsePrefix(subnet)
 		if err != nil {
-			invalid := field.Invalid(field.NewPath("spec", "serviceSubnets").Index(i), subnet, "unable to parse service subnet as prefix")
-			errorList = append(errorList, invalid)
+			errs = append(errs, field.Invalid(field.NewPath("spec", "serviceSubnets").Index(i), subnet, "unable to parse service subnet as prefix"))
 		}
 
 		for _, prefix := range prefixes {
 			if newPrefix.Overlaps(prefix) {
-				invalid := field.Invalid(field.NewPath("spec", "serviceSubnets").Index(i), subnet, "subnet overlaps with prefix "+prefix.String())
-				errorList = append(errorList, invalid)
+				errs = append(errs, field.Invalid(field.NewPath("spec", "serviceSubnets").Index(i), subnet, "subnet overlaps with prefix "+prefix.String()))
 			}
 		}
 
 		prefixes = append(prefixes, newPrefix)
 	}
 
-	if len(errorList) == 0 {
+	if len(errs) == 0 {
 		return nil
 	}
 
@@ -212,6 +190,6 @@ func (webhook *DockyardsCluster) validate(dockyardsCluster *dockyardsv1.Cluster)
 	return apierrors.NewInvalid(
 		qualifiedKind,
 		dockyardsCluster.Name,
-		errorList,
+		errs,
 	)
 }

--- a/internal/webhooks/credential_webhook.go
+++ b/internal/webhooks/credential_webhook.go
@@ -1,0 +1,89 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:,resources=secrets,verbs=create;update,path=/validate-dockyards-credential,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,name=validation.credential.dockyards.io,serviceName=dockyards-backend
+
+type DockyardsCredential struct {
+	Client client.Reader
+}
+
+var _ admission.Validator[*corev1.Secret] = &DockyardsCredential{}
+
+func (webhook *DockyardsCredential) SetupWebhookWithManager(m ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(m, &corev1.Secret{}).
+		WithValidator(webhook).
+		Complete()
+}
+
+func (webhook *DockyardsCredential) ValidateCreate(ctx context.Context, o *corev1.Secret) (admission.Warnings, error) {
+	return webhook.validate(ctx, o)
+}
+
+func (webhook *DockyardsCredential) ValidateUpdate(ctx context.Context, _, newObj *corev1.Secret) (admission.Warnings, error) {
+	return webhook.validate(ctx, newObj)
+}
+
+func (webhook *DockyardsCredential) ValidateDelete(_ context.Context, _ *corev1.Secret) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (webhook *DockyardsCredential) validate(_ context.Context, obj *corev1.Secret) (admission.Warnings, error) {
+	if obj.Type != dockyardsv1.SecretTypeCredential {
+		return nil, nil
+	}
+
+	var errs field.ErrorList
+
+	owner, err := apiutil.FindOwnerReference(obj, dockyardsv1.OrganizationKind)
+	if err != nil {
+		errs = append(errs, field.Required(
+			field.NewPath("metadata", "ownerReferences"),
+			"secret does not have a organization owner",
+		))
+	}
+
+	if value := obj.Labels[dockyardsv1.LabelOrganizationName]; value != owner.Name {
+		errs = append(errs, field.Invalid(
+			field.NewPath("metadata", "labels", dockyardsv1.LabelOrganizationName),
+			value,
+			fmt.Sprintf("expected '%s'", owner.Name),
+		))
+	}
+
+	if len(errs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(
+		dockyardsv1.GroupVersion.WithKind(dockyardsv1.MemberKind).GroupKind(),
+		obj.Name,
+		errs,
+	)
+}

--- a/internal/webhooks/invitation_webhook.go
+++ b/internal/webhooks/invitation_webhook.go
@@ -16,8 +16,10 @@ package webhooks
 
 import (
 	"context"
+	"fmt"
 	"net/mail"
 
+	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
 	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
 	"github.com/sudoswedenab/dockyards-backend/api/v1alpha3/index"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -85,12 +87,11 @@ func (webhook *DockyardsInvitation) ValidateUpdate(ctx context.Context, oldInv, 
 }
 
 func (webhook *DockyardsInvitation) validate(ctx context.Context, invitation *dockyardsv1.Invitation) (admission.Warnings, error) {
+	var errs field.ErrorList
+
 	_, err := mail.ParseAddress(invitation.Spec.Email)
 	if err != nil {
-		invalid := field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "unable to parse as address")
-		errs := field.ErrorList{invalid}
-
-		return nil, apierrors.NewInvalid(dockyardsv1.GroupVersion.WithKind(dockyardsv1.InvitationKind).GroupKind(), invitation.Name, errs)
+		errs = append(errs, field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "unable to parse as address"))
 	}
 
 	matchingFields := client.MatchingFields{
@@ -100,60 +101,87 @@ func (webhook *DockyardsInvitation) validate(ctx context.Context, invitation *do
 	var invitationList dockyardsv1.InvitationList
 	err = webhook.Client.List(ctx, &invitationList, &matchingFields, client.InNamespace(invitation.Namespace))
 	if err != nil {
-		return nil, err
+		errs = append(errs, field.InternalError(field.NewPath("spec", "email"), err))
 	}
 
 	if len(invitationList.Items) != 0 {
-		invalid := field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "address already invited")
-		errs := field.ErrorList{invalid}
-
-		return nil, apierrors.NewInvalid(dockyardsv1.GroupVersion.WithKind(dockyardsv1.InvitationKind).GroupKind(), invitation.Name, errs)
+		errs = append(errs, field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "address already invited"))
 	}
 
 	var userList dockyardsv1.UserList
 	err = webhook.Client.List(ctx, &userList, matchingFields)
 	if err != nil {
-		return nil, err
+		errs = append(errs, field.InternalError(field.NewPath("spec", "email"), err))
 	}
 
-	if len(userList.Items) == 0 {
-		return nil, nil
-	}
-
-	existingUser := userList.Items[0]
-
-	matchingFields = client.MatchingFields{
-		index.MemberReferencesField: existingUser.Name,
-	}
-
-	var organizationList dockyardsv1.OrganizationList
-	err = webhook.Client.List(ctx, &organizationList, matchingFields)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, organization := range organizationList.Items {
-		if organization.Spec.NamespaceRef == nil {
-			continue
+	for _, existingUser := range userList.Items {
+		matchingFields = client.MatchingFields{
+			index.MemberReferencesField: existingUser.Name,
 		}
 
-		if organization.Spec.NamespaceRef.Name != invitation.Namespace {
-			continue
+		var organizationList dockyardsv1.OrganizationList
+		err = webhook.Client.List(ctx, &organizationList, matchingFields)
+		if err != nil {
+			errs = append(errs, field.InternalError(field.NewPath("spec", "email"), err))
 		}
 
-		for _, memberRef := range organization.Spec.MemberRefs { //nolint:staticcheck
-			if memberRef.Name != existingUser.Name {
+		for _, organization := range organizationList.Items {
+			if organization.Spec.NamespaceRef == nil {
 				continue
 			}
 
-			invalid := field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "user already member")
-			errs := field.ErrorList{invalid}
+			if organization.Spec.NamespaceRef.Name != invitation.Namespace {
+				continue
+			}
 
-			return nil, apierrors.NewInvalid(dockyardsv1.GroupVersion.WithKind(dockyardsv1.InvitationKind).GroupKind(), invitation.Name, errs)
+			for _, memberRef := range organization.Spec.MemberRefs { //nolint:staticcheck
+				if memberRef.Name != existingUser.Name {
+					continue
+				}
+
+				errs = append(errs, field.Invalid(field.NewPath("spec", "email"), invitation.Spec.Email, "user already member"))
+
+				break
+			}
 		}
 	}
 
-	return nil, nil
+	owner, err := apiutil.FindOwnerReference(invitation, dockyardsv1.OrganizationKind)
+	if err != nil {
+		errs = append(errs, field.Required(
+			field.NewPath("metadata", "ownerReferences"),
+			"invitation does not have a organization owner",
+		))
+	}
+
+	if value := invitation.Labels[dockyardsv1.LabelOrganizationName]; value != owner.Name {
+		errs = append(errs, field.Invalid(
+			field.NewPath("metadata", "labels", dockyardsv1.LabelOrganizationName),
+			value,
+			fmt.Sprintf("expected '%s'", owner.Name),
+		))
+	}
+
+	if value := invitation.Labels[dockyardsv1.LabelRoleName]; value != string(invitation.Spec.Role) {
+		errs = append(errs, field.Invalid(
+			field.NewPath("metadata", "labels", dockyardsv1.LabelRoleName),
+			value,
+			fmt.Sprintf("expected '%s'", string(invitation.Spec.Role)),
+		))
+	}
+
+	if invitation.Spec.Role == "" {
+		errs = append(errs, field.Required(
+			field.NewPath("metadata", "spec", "role"),
+			"",
+		))
+	}
+
+	if len(errs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(dockyardsv1.GroupVersion.WithKind(dockyardsv1.InvitationKind).GroupKind(), invitation.Name, errs)
 }
 
 func (webhook *DockyardsInvitation) ValidateDelete(_ context.Context, _ *dockyardsv1.Invitation) (admission.Warnings, error) {

--- a/internal/webhooks/workload_webhook.go
+++ b/internal/webhooks/workload_webhook.go
@@ -1,0 +1,110 @@
+// Copyright 2024 Sudo Sweden AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sudoswedenab/dockyards-backend/api/apiutil"
+	dockyardsv1 "github.com/sudoswedenab/dockyards-backend/api/v1alpha3"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// +kubebuilder:webhook:groups=dockyards.io,resources=workloads,verbs=create;delete;update,path=/validate-dockyards-io-v1alpha3-workload,mutating=false,failurePolicy=fail,sideEffects=none,admissionReviewVersions=v1,name=validation.workload.dockyards.io,versions=v1alpha3,serviceName=dockyards-backend
+// +kubebuilder:webhookconfiguration:mutating=false,name=dockyards-backend
+
+// +kubebuilder:rbac:groups=dockyards.io,resources=releases,verbs=get;list;watch
+
+type DockyardsWorkload struct {
+	Client client.Reader
+}
+
+var _ admission.Validator[*dockyardsv1.Workload] = &DockyardsWorkload{}
+
+func (webhook *DockyardsWorkload) SetupWebhookWithManager(m ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(m, &dockyardsv1.Workload{}).
+		WithValidator(webhook).
+		Complete()
+}
+
+func (webhook *DockyardsWorkload) ValidateCreate(_ context.Context, obj *dockyardsv1.Workload) (admission.Warnings, error) {
+	return webhook.validate(obj)
+}
+
+func (webhook *DockyardsWorkload) ValidateDelete(_ context.Context, _ *dockyardsv1.Workload) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (webhook *DockyardsWorkload) ValidateUpdate(_ context.Context, _, newObj *dockyardsv1.Workload) (admission.Warnings, error) {
+	return webhook.validate(newObj)
+}
+
+func (webhook *DockyardsWorkload) validate(o *dockyardsv1.Workload) (admission.Warnings, error) {
+	var errs field.ErrorList
+
+	labelsField := field.NewPath("metadata", "labels")
+
+	if o.Labels[dockyardsv1.LabelOrganizationName] == "" {
+		errs = append(errs, field.Required(labelsField.Key(dockyardsv1.LabelOrganizationName), ""))
+	}
+
+	if o.Labels[dockyardsv1.LabelClusterName] == "" {
+		errs = append(errs, field.Required(labelsField.Key(dockyardsv1.LabelClusterName), ""))
+	}
+
+	if o.Labels[dockyardsv1.LabelWorkloadName] == "" {
+		errs = append(errs, field.Required(labelsField.Key(dockyardsv1.LabelWorkloadName), ""))
+	}
+
+	if o.Labels[dockyardsv1.LabelWorkloadTemplateName] == "" {
+		errs = append(errs, field.Required(labelsField.Key(dockyardsv1.LabelWorkloadTemplateName), ""))
+	}
+
+	owner, err := apiutil.FindOwnerReference(o, dockyardsv1.ClusterKind)
+	if err != nil {
+		errs = append(errs, field.InternalError(field.NewPath("metadata", "ownerReferences"), err))
+	}
+
+	if value := o.Labels[dockyardsv1.LabelClusterName]; value != owner.Name {
+		errs = append(errs, field.Invalid(
+			labelsField.Key(dockyardsv1.LabelClusterName),
+			value,
+			fmt.Sprintf("expected '%s'", owner.Name),
+		))
+	}
+
+	if value := o.Labels[dockyardsv1.LabelWorkloadTemplateName]; value != o.Spec.WorkloadTemplateRef.Name {
+		errs = append(errs, field.Invalid(
+			labelsField.Key(dockyardsv1.LabelWorkloadTemplateName),
+			value,
+			fmt.Sprintf("expected '%s'", o.Spec.WorkloadTemplateRef.Name),
+		))
+	}
+
+	if len(errs) == 0 {
+		return nil, nil
+	}
+
+	return nil, apierrors.NewInvalid(
+		dockyardsv1.GroupVersion.WithKind(dockyardsv1.WorkloadKind).GroupKind(),
+		o.Name,
+		errs,
+	)
+}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,13 @@ func setupWebhooks(mgr ctrl.Manager, allowedDomains []string) error {
 		return err
 	}
 
+	err = (&webhooks.DockyardsWorkload{
+		Client: mgr.GetClient(),
+	}).SetupWebhookWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -120,6 +120,13 @@ func setupWebhooks(mgr ctrl.Manager, allowedDomains []string) error {
 		return err
 	}
 
+	err = (&webhooks.DockyardsCredential{
+		Client: mgr.GetClient(),
+	}).SetupWebhookWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This set of patches adds a bunch more validating webhooks for labels since we may want to depend on the labels in filtering logic etc, but if the objects are created from outside the API (i.e. someone uses kubectl) we still want the object shape to look as we want.

We may want to hold off merging this until the t2 work is done, since it could snowball in to a bunch of other repos having to be updated as well, since they could _potentially_ be creating objects of their own which may not follow the contract specified by these webhooks.